### PR TITLE
hotfix Update config.lua

### DIFF
--- a/SecureServe/config.lua
+++ b/SecureServe/config.lua
@@ -122,6 +122,12 @@ SecureServe.ServerSecurity = {
     }
 }
 
+-- @ EVENT WHITELIST FOR CORE EVENT WRAPPER
+SecureServe.EventWhitelist = {
+    ["__cfx_internal:commandFallback"] = true,
+    --["playerJoining"] = true, -- Example of how to whitelist an event
+}
+
 ---@!!!IMPORTANT!!!
 -- If you wish to enjoy everything secureserve has to offer and want secureserve to work properly enable the option: EnableModule
 SecureServe.Module = {


### PR DESCRIPTION
hotfix for whitelist event for core event wrapper which will trigger ban before module event whitelist system


my case im getting ban with reason try to trigger event: '__cfx_internal:commandFallback' from resource : 'chat' 
so im trying to whitelist that event in Module.Event.Whitelist but it didnt work so im looking into it


its may not be best practice but maybe its helpful